### PR TITLE
add some fields to API for displaying more info to miners

### DIFF
--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -36,6 +36,7 @@ class WorkerBridge(worker_interface.WorkerBridge):
         self.removed_unstales_var = variable.Variable((0, 0, 0))
         self.removed_doa_unstales_var = variable.Variable(0)
         
+        self.last_work_shares = variable.Variable( {} )
         
         self.my_share_hashes = set()
         self.my_doa_share_hashes = set()
@@ -321,6 +322,9 @@ class WorkerBridge(worker_interface.WorkerBridge):
             self.current_work.value['subsidy']*1e-8, self.node.net.PARENT.SYMBOL,
             len(self.current_work.value['transactions']),
         )
+
+        #need this for stats
+        self.last_work_shares.value[bitcoin_data.pubkey_hash_to_address(pubkey_hash, self.node.net.PARENT)]=share_info['bits']
         
         ba = dict(
             version=min(self.current_work.value['version'], 2),


### PR DESCRIPTION
this patch adds some fields to local_stats and global_stats web API to
display more detailed infos to miners, especially on p2pool nodes with
more than one miner address attached.

global_stats.network_hashrate: total hashrate of coin network
global_stats.network_block_difficulty: latest block diff in coin network

local_stats.miner_last_difficulties: array of address and share difficulty
                    pairs, which lists the actual difficulty of the latest
                    share dished out to each active miner
